### PR TITLE
Re-enable shoryuken:stop

### DIFF
--- a/lib/capistrano/tasks/shoryuken.cap
+++ b/lib/capistrano/tasks/shoryuken.cap
@@ -68,6 +68,7 @@ namespace :shoryuken do
         end
       end
     end
+    Rake::Task['shoryuken:stop'].reenable
   end
   
   desc 'Shutdown the shoryuken process, immediately'


### PR DESCRIPTION
Solution for issue #3
After upgrading to capistrano 3.7.x the following warning pops up on deploy.

```
Skipping task `shoryuken:stop'.
Capistrano tasks may only be invoked once. Since task `shoryuken:stop' was previously invoked, invoke("shoryuken:stop") at /PATH_TO_GEMS/capistrano-shoryuken-0.1.5/lib/capistrano/tasks/shoryuken.cap:107 will be skipped.
If you really meant to run this task again, first call Rake::Task["shoryuken:stop"].reenable
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO.
```

`shoryuken:stop` is always called more than once on deploy. It should be allowed.
It is a same solution as capistrano-sidekiq's one. https://github.com/seuros/capistrano-sidekiq/pull/164