### PR TITLE
Fix capistrano warning for previously invoked shoryuken:stop

### DIFF
--- a/lib/capistrano/tasks/shoryuken.cap
+++ b/lib/capistrano/tasks/shoryuken.cap
@@ -22,9 +22,6 @@ namespace :deploy do
   before :starting, :check_shoryuken_hooks do
     invoke 'shoryuken:add_default_hooks' if fetch(:shoryuken_default_hooks)
   end
-  after :publishing, :restart_shoryuken do
-    invoke 'shoryuken:restart' if fetch(:shoryuken_default_hooks)
-  end
 end
 
 namespace :shoryuken do
@@ -50,8 +47,8 @@ namespace :shoryuken do
   
   task :add_default_hooks do
     after 'deploy:updated', 'shoryuken:stop'
-    after 'deploy:reverted', 'shoryuken:stop'
     after 'deploy:published', 'shoryuken:start'
+    after 'deploy:failed', 'shoryuken:restart'
   end
 
   desc 'Stop the shoryuken process, gracefully'
@@ -104,8 +101,8 @@ namespace :shoryuken do
 
   desc 'Restart shoryuken'
   task :restart do
-    invoke 'shoryuken:stop'
-    invoke 'shoryuken:start'
+    invoke! 'shoryuken:stop'
+    invoke! 'shoryuken:start'
   end
   
   desc 'Make the shoryuken process log detailed status information'


### PR DESCRIPTION
This fixes the capistrano warning described in https://github.com/joekhoobyar/capistrano-shoryuken/issues/3. Rather than calling `reenable` again on the task as in https://github.com/joekhoobyar/capistrano-shoryuken/pull/4, I've copied the same solution that was applied in sidekiq. It makes use of the new capistrano API method `invoke!` and was applied here: https://github.com/seuros/capistrano-sidekiq/commit/2a9e46f61bed00e1d897737e44d939c6b6f2db2d.